### PR TITLE
In meltReadPairs, move the names from rows to elementMetadata

### DIFF
--- a/R/deletion-utils.R
+++ b/R/deletion-utils.R
@@ -1594,7 +1594,7 @@ thinReadPairs <- function(object, max.out=25e3){
 }
 
 meltReadPairs <- function(rps){
-  is.improper <- names(rps) != ""
+  is.improper <- elementMetadata(rps)$names != ""
   names(rps) <- NULL
   df <- data.frame(seqnames=as.character(seqnames(rps)),
                   start.first=start(first(rps)), end.first=end(first(rps)),


### PR DESCRIPTION
We updated the variant object to carry names in elementMetadata. This function also needed an update.